### PR TITLE
Update fast_FOAV.m - variables are allocated based on sample size

### DIFF
--- a/fast_FOAV.m
+++ b/fast_FOAV.m
@@ -14,9 +14,9 @@ x = x(1:30000);
 
 %% Computing FOAV
 
-Corr_size = 1:1:10000;
+Corr_size = 1:1:fix(numel(x)./2);
 count = 4;
-N = 30000;
+N = numel(x);
 xpc = x(1:N);
 
 tic;


### PR DESCRIPTION
I have updated the fast_FOAV in such a way the variables are allocated according input data size. It is easier now to change size of input data and take a look at the calculation